### PR TITLE
Flush app-insights client after batch processing

### DIFF
--- a/src/AppInsightsPHP/Monolog/Handler/AppInsightsDependencyHandler.php
+++ b/src/AppInsightsPHP/Monolog/Handler/AppInsightsDependencyHandler.php
@@ -44,6 +44,12 @@ final class AppInsightsDependencyHandler extends AbstractProcessingHandler
         );
     }
 
+    public function handleBatch(array $records)
+    {
+        parent::handleBatch($records);
+        $this->reset();
+    }
+
     protected function getDefaultFormatter()
     {
         return new ContextFlatterFormatter();
@@ -56,6 +62,6 @@ final class AppInsightsDependencyHandler extends AbstractProcessingHandler
 
     public function close()
     {
-        return $this->reset();
+        $this->reset();
     }
 }

--- a/src/AppInsightsPHP/Monolog/Handler/AppInsightsTraceHandler.php
+++ b/src/AppInsightsPHP/Monolog/Handler/AppInsightsTraceHandler.php
@@ -62,6 +62,12 @@ final class AppInsightsTraceHandler extends AbstractProcessingHandler
         );
     }
 
+    public function handleBatch(array $records)
+    {
+        parent::handleBatch($records);
+        $this->reset();
+    }
+
     protected function getDefaultFormatter()
     {
         return new ContextFlatterFormatter();
@@ -74,6 +80,6 @@ final class AppInsightsTraceHandler extends AbstractProcessingHandler
 
     public function close()
     {
-        return $this->reset();
+        $this->reset();
     }
 }

--- a/tests/AppInsightsPHP/Monolog/Tests/Handler/AppInsightsTraceHandlerTest.php
+++ b/tests/AppInsightsPHP/Monolog/Tests/Handler/AppInsightsTraceHandlerTest.php
@@ -10,35 +10,39 @@ use AppInsightsPHP\Monolog\Handler\AppInsightsTraceHandler;
 use ApplicationInsights\Channel\Contracts\Message_Severity_Level;
 use ApplicationInsights\Telemetry_Client;
 use Monolog\Logger;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 final class AppInsightsTraceHandlerTest extends TestCase
 {
-    public function test_log_record()
+    public function test_log_record(): void
     {
         $logDate = new \DateTimeImmutable('2019-01-01 10:00:00');
+        $message = 'test message';
+        $context = ['foo' => 'bar'];
 
         $telemetry = $this->createMock(Telemetry_Client::class);
-        $telemetry->expects($this->once())
-            ->method('trackMessage')
-            ->with(
-                'test message',
-                Message_Severity_Level::INFORMATION,
-                [
-                    'channel' => 'test',
-                    'datetime' => $logDate->format('c'),
-                    'monolog_level' => 'DEBUG',
-                    'foo' => 'bar'
-                ]
-            );
-
+        $this->expectsMessageToBeTracked($telemetry, $logDate, $message, $context);
 
         $handler = new AppInsightsTraceHandler(new Client($telemetry, Configuration::createDefault()));
 
-        $handler->handle($this->getRecord($logDate, Logger::DEBUG, 'test message', ['foo' => 'bar']));
+        $handler->handle($this->getRecord($logDate, Logger::DEBUG, $message, $context));
     }
 
-    protected function getRecord(\DateTimeInterface $dateTime, $level = Logger::WARNING, $message = 'test', $context = array())
+    public function test_sent_message_to_app_insights_after_batch_processing(): void
+    {
+        $telemetry = $this->createMock(Telemetry_Client::class);
+        $this->expectsMessageToBeTracked($telemetry, $logDate = new \DateTimeImmutable('2019-01-01 10:00:00'));
+
+        // two times, because the first time is after batc processing and the second time in the object destructor
+        $telemetry->expects($this->exactly(2))->method('flush');
+
+        $handler = new AppInsightsTraceHandler(new Client($telemetry, Configuration::createDefault()));
+
+        $handler->handleBatch([$this->getRecord($logDate, Logger::DEBUG)]);
+    }
+
+    protected function getRecord(\DateTimeInterface $dateTime, $level = Logger::WARNING, string $message = 'test', array $context = []): array
     {
         return [
             'message' => $message,
@@ -49,5 +53,24 @@ final class AppInsightsTraceHandlerTest extends TestCase
             'datetime' => $dateTime,
             'extra' => [],
         ];
+    }
+
+    private function expectsMessageToBeTracked(MockObject $telemetry, \DateTimeImmutable $logDate, string $message = 'test', array $context = []): void
+    {
+        $telemetry->expects($this->once())
+            ->method('trackMessage')
+            ->with(
+                $message,
+                Message_Severity_Level::INFORMATION,
+                \array_merge(
+                    [
+                        'channel' => 'test',
+                        'datetime' => $logDate->format('c'),
+                        'monolog_level' => 'DEBUG',
+                    ],
+                    $context
+                )
+            )
+        ;
     }
 }


### PR DESCRIPTION
To make a use of https://github.com/Seldaek/monolog/blob/master/src/Monolog/Handler/BufferHandler.php#L91
we should flush `TelemetryClient` after processing batch records.